### PR TITLE
Allow for disabling the default Examine indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,29 @@ public class MyIndexManagerComposer : IComposer
 }
 ```
 
+## Optimizing server resources
+
+The default Examine indexes from Umbraco CMS are no longer in use, if this search provider powers all things search - that is:
+
+* Frontend search.
+* Backoffice search.
+* The Delivery API (if applicable on your site).
+
+However, Umbraco CMS continues to keep them up-to-date with content changes. Since this is a waste of server resources, the default Examine indexes can be explicitly disabled by means of composition:
+
+```csharp
+using Umbraco.Cms.Core.Composing;
+using Kjac.SearchProvider.Elasticsearch.DependencyInjection;
+
+namespace My.Site;
+
+public class DisableDefaultIndexesComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+        => builder.DisableDefaultExamineIndexes();
+}
+```
+
 ## Contributing
 
 Yes, please ❤️

--- a/src/Kjac.SearchProvider.Elasticsearch/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Kjac.SearchProvider.Elasticsearch/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -1,12 +1,15 @@
-﻿using Kjac.SearchProvider.Elasticsearch.Extensions;
+﻿using Examine;
+using Kjac.SearchProvider.Elasticsearch.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
-using Umbraco.Cms.Search.Core.Configuration;
 using Umbraco.Cms.Search.Core.Services.ContentIndexing;
 using Kjac.SearchProvider.Elasticsearch.NotificationHandlers;
+using Kjac.SearchProvider.Elasticsearch.Services;
+using Umbraco.Extensions;
 using CoreConstants = Umbraco.Cms.Search.Core.Constants;
+using IndexOptions = Umbraco.Cms.Search.Core.Configuration.IndexOptions;
 
 namespace Kjac.SearchProvider.Elasticsearch.DependencyInjection;
 
@@ -45,6 +48,14 @@ public static class UmbracoBuilderExtensions
 
         // ensure all indexes exist before Umbraco has finished start-up
         builder.AddNotificationAsyncHandler<UmbracoApplicationStartingNotification, EnsureIndexesNotificationHandler>();
+
+        return builder;
+    }
+
+    public static IUmbracoBuilder DisableDefaultExamineIndexes(this IUmbracoBuilder builder)
+    {
+        builder.Services.AddSingleton<ExamineManager>();
+        builder.Services.AddUnique<IExamineManager, MaskedCoreIndexesExamineManager>();
 
         return builder;
     }

--- a/src/Kjac.SearchProvider.Elasticsearch/Services/MaskedCoreIndexesExamineManager.cs
+++ b/src/Kjac.SearchProvider.Elasticsearch/Services/MaskedCoreIndexesExamineManager.cs
@@ -1,0 +1,43 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Examine;
+
+namespace Kjac.SearchProvider.Elasticsearch.Services;
+
+internal sealed class MaskedCoreIndexesExamineManager : IExamineManager
+{
+    private readonly string[] _coreIndexes =
+    [
+        Umbraco.Cms.Core.Constants.UmbracoIndexes.DeliveryApiContentIndexName,
+        Umbraco.Cms.Core.Constants.UmbracoIndexes.ExternalIndexName,
+        Umbraco.Cms.Core.Constants.UmbracoIndexes.InternalIndexName,
+        Umbraco.Cms.Core.Constants.UmbracoIndexes.MembersIndexName,
+    ];
+
+    private readonly ExamineManager _inner;
+
+    public MaskedCoreIndexesExamineManager(ExamineManager inner)
+        => _inner = inner;
+
+    public void Dispose()
+        => _inner.Dispose();
+
+    public bool TryGetIndex(string indexName, [MaybeNullWhen(false)] [UnscopedRef] out IIndex index)
+    {
+        if (_coreIndexes.Contains(indexName) is false)
+        {
+            return _inner.TryGetIndex(indexName, out index);
+        }
+
+        index = null;
+        return false;
+    }
+
+    public bool TryGetSearcher(string searcherName, [MaybeNullWhen(false)] [UnscopedRef] out ISearcher searcher)
+        => _inner.TryGetSearcher(searcherName, out searcher);
+
+    public IEnumerable<IIndex> Indexes
+        => _inner.Indexes.Where(index => _coreIndexes.Contains(index.Name) is false).ToArray();
+
+    public IEnumerable<ISearcher> RegisteredSearchers
+        => _inner.RegisteredSearchers;
+}


### PR DESCRIPTION
Fixes #3 

This follows the same pattern as the default Examine search provider (see [docs](https://docs.umbraco.com/umbraco-search/getting-started/examine-search-provider#optimizing-server-resources)).